### PR TITLE
Add InterpretationType Enum and Update Services for Dream Interpretation

### DIFF
--- a/AIDreamDecoder.Application/Dtos/DreamAnalysisDtos/DreamAnalysisDto.cs
+++ b/AIDreamDecoder.Application/Dtos/DreamAnalysisDtos/DreamAnalysisDto.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AIDreamDecoder.Domain.Enums;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,5 +15,6 @@ namespace AIDreamDecoder.Application.Dtos.DreamAnalysisDtos
         public string AnalysisResult { get; set; } // Analiz sonucu (yorum, anlam vs.)
         public string Status { get; set; } // Analiz durumu (Tamamlandı, İşleniyor vs.)
         public DateTime CreatedAt { get; set; } // Analizin oluşturulma tarihi
+        public InterpretationType InterpretationType { get; set; }
     }
 }

--- a/AIDreamDecoder.Application/Interfaces/IAIDreamInterpreterService.cs
+++ b/AIDreamDecoder.Application/Interfaces/IAIDreamInterpreterService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AIDreamDecoder.Domain.Enums;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +9,6 @@ namespace AIDreamDecoder.Application.Interfaces
 {
     public interface IAIDreamInterpreterService
     {
-        Task<string> InterpretDreamAsync(string dreamDescription);
+        Task<string> InterpretDreamAsync(string dreamDescription, InterpretationType InterpretationType);
     }
 }

--- a/AIDreamDecoder.Domain/Entities/DreamAnalysis.cs
+++ b/AIDreamDecoder.Domain/Entities/DreamAnalysis.cs
@@ -14,6 +14,7 @@ namespace AIDreamDecoder.Domain.Entities
         public string AnalysisResult { get; set; } // Analiz sonucu (örneğin, anlamlar veya yorumlar)
         public AnalysisStatus Status { get; set; } // Analizin durumu
         public DateTime CreatedAt { get; set; } // Analizin oluşturulma tarihi
+        public InterpretationType InterpretationType { get; set; } //Yorumlama türü eklendi
 
         // Navigation Property
         public Dream Dream { get; set; } // Analizi yapılan rüya

--- a/AIDreamDecoder.Domain/Enums/InterpretationType.cs
+++ b/AIDreamDecoder.Domain/Enums/InterpretationType.cs
@@ -8,10 +8,10 @@ namespace AIDreamDecoder.Domain.Enums
 {
     public enum InterpretationType
     {
-        Freud = 1,
-        Jung = 2,
-        Aristoteles = 3,
-        Descartes = 4,
-        Islami = 5
+        Freud = 0,
+        Jung = 1,
+        Aristoteles = 2,
+        Descartes = 3,
+        Islami = 4
     }
 }

--- a/AIDreamDecoder.Infrastructure/Persistence/Migrations/ApplicationDB/20250208184440_InitialCreate.Designer.cs
+++ b/AIDreamDecoder.Infrastructure/Persistence/Migrations/ApplicationDB/20250208184440_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AIDreamDecoder.Infrastructure.Persistence.Migrations.ApplicationDB
 {
     [DbContext(typeof(AIDreamDecoderDbContext))]
-    [Migration("20250123163635_InitialCreate")]
+    [Migration("20250208184440_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -37,6 +37,9 @@ namespace AIDreamDecoder.Infrastructure.Persistence.Migrations.ApplicationDB
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasColumnType("text");
+
+                    b.Property<int>("InterpretationType")
+                        .HasColumnType("integer");
 
                     b.Property<Guid>("UserId")
                         .HasColumnType("uuid");
@@ -63,6 +66,9 @@ namespace AIDreamDecoder.Infrastructure.Persistence.Migrations.ApplicationDB
 
                     b.Property<Guid>("DreamId")
                         .HasColumnType("uuid");
+
+                    b.Property<int>("InterpretationType")
+                        .HasColumnType("integer");
 
                     b.Property<int>("Status")
                         .HasColumnType("integer");

--- a/AIDreamDecoder.Infrastructure/Persistence/Migrations/ApplicationDB/20250208184440_InitialCreate.cs
+++ b/AIDreamDecoder.Infrastructure/Persistence/Migrations/ApplicationDB/20250208184440_InitialCreate.cs
@@ -33,6 +33,7 @@ namespace AIDreamDecoder.Infrastructure.Persistence.Migrations.ApplicationDB
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     UserId = table.Column<Guid>(type: "uuid", nullable: false),
                     Description = table.Column<string>(type: "text", nullable: false),
+                    InterpretationType = table.Column<int>(type: "integer", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>
@@ -54,7 +55,8 @@ namespace AIDreamDecoder.Infrastructure.Persistence.Migrations.ApplicationDB
                     DreamId = table.Column<Guid>(type: "uuid", nullable: false),
                     AnalysisResult = table.Column<string>(type: "text", nullable: false),
                     Status = table.Column<int>(type: "integer", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    InterpretationType = table.Column<int>(type: "integer", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/AIDreamDecoder.Infrastructure/Persistence/Migrations/ApplicationDB/AIDreamDecoderDbContextModelSnapshot.cs
+++ b/AIDreamDecoder.Infrastructure/Persistence/Migrations/ApplicationDB/AIDreamDecoderDbContextModelSnapshot.cs
@@ -35,6 +35,9 @@ namespace AIDreamDecoder.Infrastructure.Persistence.Migrations.ApplicationDB
                         .IsRequired()
                         .HasColumnType("text");
 
+                    b.Property<int>("InterpretationType")
+                        .HasColumnType("integer");
+
                     b.Property<Guid>("UserId")
                         .HasColumnType("uuid");
 
@@ -60,6 +63,9 @@ namespace AIDreamDecoder.Infrastructure.Persistence.Migrations.ApplicationDB
 
                     b.Property<Guid>("DreamId")
                         .HasColumnType("uuid");
+
+                    b.Property<int>("InterpretationType")
+                        .HasColumnType("integer");
 
                     b.Property<int>("Status")
                         .HasColumnType("integer");

--- a/AIDreamDecoder.Infrastructure/Services/DreamService.cs
+++ b/AIDreamDecoder.Infrastructure/Services/DreamService.cs
@@ -94,7 +94,7 @@ namespace AIDreamDecoder.Infrastructure.Services
             {
                 _logger.LogInformation("Starting dream interpretation for user {UserId}", dreamDto.UserId);
 
-                var interpretation = await _aiService.InterpretDreamAsync(dreamDto.Description);
+                var interpretation = await _aiService.InterpretDreamAsync(dreamDto.Description, dreamDto.InterpretationType);
 
                 var dream = new Dream
                 {
@@ -106,7 +106,8 @@ namespace AIDreamDecoder.Infrastructure.Services
                         Id = Guid.NewGuid(),
                         AnalysisResult = interpretation,
                         Status = AnalysisStatus.Completed,
-                        CreatedAt = DateTime.UtcNow
+                        CreatedAt = DateTime.UtcNow,
+                        InterpretationType = dreamDto.InterpretationType
                     }
                 };
 
@@ -125,7 +126,7 @@ namespace AIDreamDecoder.Infrastructure.Services
         public async Task<DreamDto> AddDreamWithInterpretationAsync(DreamDto dreamDto)
         {
             // Get AI interpretation
-            var interpretation = await _aiService.InterpretDreamAsync(dreamDto.Description);
+            var interpretation = await _aiService.InterpretDreamAsync(dreamDto.Description, dreamDto.InterpretationType);
 
             // Create dream entity
             var dream = new Dream
@@ -135,7 +136,8 @@ namespace AIDreamDecoder.Infrastructure.Services
                 Analysis = new DreamAnalysis
                 {
                     AnalysisResult = interpretation,
-                    Status = AnalysisStatus.Completed
+                    Status = AnalysisStatus.Completed,
+                    InterpretationType=dreamDto.InterpretationType
                 }
             };
 
@@ -172,7 +174,7 @@ namespace AIDreamDecoder.Infrastructure.Services
                 _logger.LogInformation("User {UserId} found or created", userId);
 
                 // AI tabanlı rüya analizi al
-                var interpretation = await _aiService.InterpretDreamAsync(dreamDto.Description);
+                var interpretation = await _aiService.InterpretDreamAsync(dreamDto.Description, dreamDto.InterpretationType);
 
                 // Yeni rüya oluştur
                 var dream = new Dream
@@ -183,7 +185,8 @@ namespace AIDreamDecoder.Infrastructure.Services
                     {
                         AnalysisResult = interpretation,
                         Status = AnalysisStatus.Completed,
-                        CreatedAt = DateTime.UtcNow
+                        CreatedAt = DateTime.UtcNow,
+                        InterpretationType = dreamDto.InterpretationType
                     }
                 };
 

--- a/AIDreamDecoder.Infrastructure/Services/OpenAIDreamInterpreterService.cs
+++ b/AIDreamDecoder.Infrastructure/Services/OpenAIDreamInterpreterService.cs
@@ -5,6 +5,7 @@ using OpenAI.ObjectModels.RequestModels;
 using OpenAI.ObjectModels;
 using OpenAI.Managers;
 using OpenAI.Interfaces;
+using AIDreamDecoder.Domain.Enums;
 
 namespace AIDreamDecoder.Infrastructure.Services
 {
@@ -19,21 +20,40 @@ namespace AIDreamDecoder.Infrastructure.Services
             _settings = settings.Value;
         }
 
-        public async Task<string> InterpretDreamAsync(string dreamDescription)
+        public async Task<string> InterpretDreamAsync(string dreamDescription, InterpretationType InterpretationType)
         {
             try
             {
+                string systemMessage = InterpretationType switch
+                {
+                    InterpretationType.Freud => @"You are a skilled dream interpreter using Freudian psychology. 
+                Analyze dreams with a focus on unconscious desires, childhood experiences, and symbolic meanings. 
+                Provide interpretations that explore hidden emotions and psychological conflicts.",
+
+                    InterpretationType.Jung => @"You are a skilled dream interpreter using Jungian psychology. 
+                Analyze dreams with a focus on archetypes, collective unconscious, and personal growth. 
+                Provide interpretations that explore the dreamer's journey towards self-realization.",
+
+                    InterpretationType.Aristoteles => @"You are a skilled dream interpreter using Aristotelian philosophy. 
+                Analyze dreams with a focus on logic, reason, and the nature of reality. 
+                Provide interpretations that explore the dream's connection to the dreamer's waking life.",
+
+                    InterpretationType.Descartes => @"You are a skilled dream interpreter using Cartesian philosophy. 
+                Analyze dreams with a focus on the mind-body duality and the nature of existence. 
+                Provide interpretations that explore the dream's connection to the dreamer's consciousness.",
+
+                    InterpretationType.Islami => @"You are a skilled dream interpreter using Islamic teachings. 
+                Analyze dreams with a focus on spiritual meanings, divine messages, and prophetic visions. 
+                Provide interpretations that align with Islamic principles and provide guidance.",
+
+                    _ => throw new ArgumentOutOfRangeException(nameof(InterpretationType), "Invalid interpretation approach.")
+                };
                 var completionResult = await _openAiService.ChatCompletion.CreateCompletion(new ChatCompletionCreateRequest
                 {
                     Messages = new List<ChatMessage>
                     {
-                        ChatMessage.FromSystem(@"You are a skilled dream interpreter. 
-                            Analyze dreams with psychological insight, cultural awareness, 
-                            and sensitivity. Provide interpretations that are thoughtful, 
-                            supportive, and non-judgmental. Consider multiple possible 
-                            meanings and their psychological significance. Always provide 
-                            a detailed and structured response."),
-                        ChatMessage.FromUser($"Please interpret this dream: {dreamDescription}")
+                       ChatMessage.FromSystem(systemMessage), // Yaklaşıma özel sistem mesajı
+                       ChatMessage.FromUser($"Please interpret this dream: {dreamDescription}") // Kullanıcı mesajı
                     },
                     Model = Models.Gpt_4,
                     MaxTokens = _settings.MaxTokens,


### PR DESCRIPTION
- Added the `InterpretationType` enum to standardize dream interpretation methods (Freud, Jung, Aristoteles, Descartes, Islami).
- Updated `DreamAnalysis` and related models to include `InterpretationType`.
- Modified `IAIDreamInterpreterService` and its implementations to accept `InterpretationType` as a parameter.
- Updated database migrations to reflect the new `InterpretationType` field.
- Adjusted all services (`DreamService`, `OpenAIDreamInterpreterService`) to handle the new interpretation type logic.